### PR TITLE
Fix: non linear kicker / field kick

### DIFF
--- a/python/src/elements.cc
+++ b/python/src/elements.cc
@@ -14,10 +14,12 @@
 #include <thor_scsi/elements/octupole.h>
 #include <thor_scsi/elements/corrector.h>
 #include <thor_scsi/elements/cavity.h>
+#include <thor_scsi/custom/nonlinear_kicker.h>
 
 
 namespace tse = thor_scsi::elements;
 namespace tsc = thor_scsi::core;
+namespace tsu = thor_scsi::custom;
 namespace py = pybind11;
 
 #warning "implement using cdbl properly (templating  elemtype  etc)"
@@ -259,6 +261,12 @@ struct TemplatedClasses
 			.def(py::init<const Config &>());
 
 
+		std::string nlk_name =  "NonLinearKicker" + this->m_suffix;
+		typedef tsu::NonLinearKickerTypeWithKnob<C> nlk;
+		py::class_<nlk, std::shared_ptr<nlk>>(this->m_module, nlk_name.c_str(), field_kick)
+			.def("get_field_interpolator", &nlk::getFieldInterpolator)
+			.def("set_field_interpolator", &nlk::setFieldInterpolator)
+			.def(py::init<const Config &>());
 		return elem_type;
 	}
 };

--- a/python/src/interpolation.cc
+++ b/python/src/interpolation.cc
@@ -331,6 +331,23 @@ void py_thor_scsi_init_field_interpolation(py::module &m) {
 /* for communicating the field description		*/
 		PYBIND11_NUMPY_DTYPE(tsu::aircoil_filament_t, x, y, current);
 
+    py::class_<tsu::aircoil_filament_t> aircoil_filament(m, "aircoil_filament");
+    aircoil_filament
+        .def_readwrite("x", &tsu::aircoil_filament_t::x)
+        .def_readwrite("y", &tsu::aircoil_filament_t::y)
+        .def_readwrite("current", &tsu::aircoil_filament_t::y)
+        .def("__repr__",  [](tsu::aircoil_filament_t& filament){
+            std::stringstream strm;
+            filament.show(strm, 10);
+            return strm.str();
+        })
+        .def(py::init([](const double x, const double y, const double current){
+            tsu::aircoil_filament_t f = {x, y, current};
+            return f;
+        }))
+        ;
+
+
 	py::class_<
 	    tsu:: AirCoilMagneticFieldKnobbed<tsc::StandardDoubleType>,
 	    std::shared_ptr<tsu:: AirCoilMagneticFieldKnobbed<tsc::StandardDoubleType>>
@@ -340,18 +357,28 @@ void py_thor_scsi_init_field_interpolation(py::module &m) {
 	aircoil_magnetic_field
 	    .def("set_scale", &tsu::AirCoilMagneticFieldKnobbed<tsc::StandardDoubleType>::setScale)
 	    .def("get_scale", &tsu::AirCoilMagneticFieldKnobbed<tsc::StandardDoubleType>::getScale)
+        .def("get_used_filaments", [](tsu::AirCoilMagneticFieldKnobbed<tsc::StandardDoubleType>& inst){
+            auto tmp = inst.getUsedFilaments();
+            return (tmp);
+        })
 	    .def(py::init([](py::array_t<tsu::aircoil_filament_t, py::array::c_style|py::array::forcecast>& a) {
 		return tsu::AirCoilMagneticField(aircoil_filaments_from_array(a));
 	    }) , "initalise with filaments (x, y, current)");
 
 	py::class_<
-	    tsu:: NonlinearKickerKnobbed<tsc::StandardDoubleType>,
-	    std::shared_ptr<tsu:: NonlinearKickerKnobbed<tsc::StandardDoubleType>>
+	    tsu:: NonLinearKickerInterpolationKnobbed<tsc::StandardDoubleType>,
+	    std::shared_ptr<tsu:: NonLinearKickerInterpolationKnobbed<tsc::StandardDoubleType>>
 	    >
-	    nonlinear_kicker(m, "NonlinearKicker", aircoil_magnetic_field);
+	    nonlinear_kicker(m, "NonLinearKickerInterpolation", aircoil_magnetic_field);
 
 	nonlinear_kicker
+            .def(py::init<std::vector<tsu::aircoil_filament_t>>(),
+                 "initalise with filaments (x, y, current) of one quater")
+                 ;
+    /*
 	    .def(py::init([](py::array_t<tsu::aircoil_filament_t, py::array::c_style|py::array::forcecast>& a) {
-		return tsu::NonlinearKicker(aircoil_filaments_from_array(a));
-	    }), "initalise with filaments (x, y, current) of one quater");
+		return tsu::NonLinearKickerInterpolation(aircoil_filaments_from_array(a));
+	    }
+     */
+     ;
 }

--- a/src/thor_scsi/CMakeLists.txt
+++ b/src/thor_scsi/CMakeLists.txt
@@ -71,6 +71,7 @@ set(thor_scsi_element_HEADERS
 set(thor_scsi_custom_HEADERS
   custom/aircoil_interpolation.h
   custom/nonlinear_kicker_interpolation.h
+  custom/nonlinear_kicker.h
   )
 
 set(thor_scsi_std_machine_HEADERS
@@ -105,6 +106,7 @@ set(thor_scsi_core_FILES
 
   custom/aircoil_interpolation.cc
   custom/nonlinear_kicker_interpolation.cc
+  custom/nonlinear_kicker.cc
 
   # to be removed as soon as tps is removed ...
   ss_vect_tps.cc

--- a/src/thor_scsi/custom/CMakeLists.txt
+++ b/src/thor_scsi/custom/CMakeLists.txt
@@ -35,3 +35,22 @@ target_link_libraries(test_nonlinear_kicker_interpolation
     ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
 )
 add_test(nonlinear_kicker_interpolation test_nonlinear_kicker_interpolation)
+
+add_executable(test_nonlinear_kicker test_nonlinear_kicker.cc)
+target_include_directories(test_nonlinear_kicker
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+)
+target_link_libraries(test_nonlinear_kicker
+  thor_scsi
+  thor_scsi_core
+  tpsa_lin
+  gtpsa-c++
+  gtpsa
+  # PRIVATE Boost::boost
+  #  quadmath
+    ${Boost_PRG_EXEC_MONITOR_LIBRARY}
+    ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
+)
+add_test(nonlinear_kicker test_nonlinear_kicker)

--- a/src/thor_scsi/custom/aircoil_interpolation.h
+++ b/src/thor_scsi/custom/aircoil_interpolation.h
@@ -1,8 +1,12 @@
 #ifndef _THOR_SCSI_CUSTOM_AIRCOIL_INTERPOLATION_H_
 #define _THOR_SCSI_CUSTOM_AIRCOIL_INTERPOLATION_H_ 1
 
+#include <ostream>
 #include <vector>
+#include <gtpsa/utils.hpp>
+#include <gtpsa/utils_tps.hpp>
 #include <thor_scsi/core/field_interpolation.h>
+
 
 namespace thor_scsi::custom {
 	struct aircoil_filament {
@@ -19,42 +23,67 @@ namespace thor_scsi::custom {
 	typedef struct aircoil_filament aircoil_filament_t;
 
 	template<class C>
-	class AirCoilMagneticFieldKnobbed : thor_scsi::core::Field2DInterpolationKnobbed<C> {
-		const std::vector<aircoil_filament_t> m_filaments;
+	class AirCoilMagneticFieldKnobbed : public thor_scsi::core::Field2DInterpolationKnobbed<C> {
+	        const std::vector<aircoil_filament_t> m_filaments;
 	        double m_scale;
+
+	protected:
+	    // subclasses will "multiply the number of filaments during initalisation"
+	    inline void setFilaments(const std::vector<aircoil_filament_t> filaments){ this->m_filaments = filaments;}
+
 	public:
-	    AirCoilMagneticFieldKnobbed(const std::vector<aircoil_filament_t> filaments, const double scale=1e0)
+	    AirCoilMagneticFieldKnobbed(const std::vector<aircoil_filament_t> filaments, const double scale=0e0)
 			: m_filaments(filaments)
 			, m_scale(scale)
 			{}
+
 		virtual ~AirCoilMagneticFieldKnobbed() {}
 
-	        void setScale(const double scale) {this->m_scale = scale; }
-	        const double getScale(void) const { return this->m_scale; }
+		void setScale(const double scale) { this->m_scale = scale; }
+		const double getScale(void) const { return this->m_scale;  }
+
+		// required for inspection: e.g. if python transfers filaments correctly
+		inline std::vector<aircoil_filament_t> getUsedFilaments(void) const {
+			return this->m_filaments;
+		}
+
 
 		/*
 		 * equivalent python code
-		  r2 = np.sum(dpos ** 2, axis=0)
-		  dx, dy = dpos
-		  dpos_cross = np.array([dy, dx])
-		  B = self.precomp * 1 / r2 * dpos_cross
-		  B = np.sum(B, axis=1)
-		  field[0] = B[0]
-		  field[1] = B[1]
-		*/
+		 * r2 = np.sum(dpos ** 2, axis=0)
+		 * dx, dy = dpos
+		 * dpos_cross = np.array([dy, dx])
+		 * B = self.precomp * 1 / r2 * dpos_cross
+		 * B = np.sum(B, axis=1)
+		 * field[0] = B[0]
+		 * field[1] = B[1]
+		 */
 		template<typename T>
-		inline void _field(const T& x, const T& y, T *Bx, T *By) const {
-		    const double mu0 = 4 * M_PI * 1e-7;
-		    const double precomp = mu0 / (2 * M_PI) * this->m_scale;
-		    *Bx = 0e0;
-		    *By = 0e0;
-		    for(const auto& f: this->m_filaments){
-			const auto dx = x - f.x;
-			const auto dy = y - f.y;
-			const auto r2 = dx*dx + dy*dy;
-			*By += precomp * f.current / r2 * dx;
-			*Bx += precomp * f.current / r2 * dy;
-		    }
+		inline void _field(const T& x, const T& y, T *pBx, T *pBy) const {
+			const double mu0 = 4 * M_PI * 1e-7;
+			const double precomp = mu0 / (2 * M_PI) * this->m_scale;
+
+			/*
+			 * better allocate new ones and copy back
+			 * otherwise: for tpsa objects don't forget to clear them
+			 * including gradients!
+			 *
+			 * new allocation does that for us ...
+			 */
+			T Bx = gtpsa::same_as_instance(*pBx);
+			T By = gtpsa::same_as_instance(*pBx);
+
+			for(const auto& f: this->m_filaments){
+				const auto dx = x - f.x;
+				const auto dy = y - f.y;
+				const auto r2 = dx*dx + dy*dy;
+				By += precomp * f.current / r2 * dx;
+				Bx += precomp * f.current / r2 * dy;
+			}
+
+			*pBx = std::move(Bx);
+			*pBy = std::move(By);
+
 		}
 
 		template<typename T>
@@ -68,7 +97,7 @@ namespace thor_scsi::custom {
 		inline void field(const gtpsa::tpsa& x, const gtpsa::tpsa& y, gtpsa::tpsa *Bx, gtpsa::tpsa *By) const override final
 			{
 				this->_field(x, y, Bx, By);
-			}
+            }
 		inline void field(const tps& x, const tps& y, tps *Bx, tps *By) const override final
 			{
 				this->_field(x, y, Bx, By);

--- a/src/thor_scsi/custom/nonlinear_kicker.cc
+++ b/src/thor_scsi/custom/nonlinear_kicker.cc
@@ -1,0 +1,2 @@
+// check that syntax is correct
+#include <thor_scsi/custom/nonlinear_kicker.h>

--- a/src/thor_scsi/custom/nonlinear_kicker.h
+++ b/src/thor_scsi/custom/nonlinear_kicker.h
@@ -1,0 +1,83 @@
+#ifndef _THOR_SCSI_ELEMENTS_NONLINEAR_KICKER_H_
+#define _THOR_SCSI_ELEMENTS_NONLINEAR_KICKER_H_
+
+#include <thor_scsi/elements/field_kick.h>
+#include <thor_scsi/custom/nonlinear_kicker_interpolation.h>
+
+#include <iomanip>
+
+namespace thor_scsi::custom {
+    template<class C, typename = typename C::complex_type, typename = typename C::double_type> // CK for complex knob
+    class NonLinearKickerTypeWithKnob : public thor_scsi::elements::FieldKickKnobbed<C> {
+    protected:
+        using complex_type = typename C::complex_type;
+        using double_type = typename C::double_type;
+        using nonlinearkicker_knobbed = thor_scsi::custom::NonLinearKickerInterpolationKnobbed<C>;
+	public:
+		/**
+		 *
+		 * \verbatim embed:rst:leading-asterisk
+		 *
+		 * .. Warning::
+		 *
+		 *     fix memory handling of interpolation object
+		 *     add move constructor
+		 *
+		 * \endverbatim
+		 */
+		inline NonLinearKickerTypeWithKnob(const Config &config) : thor_scsi::elements::FieldKickKnobbed<C>(config){
+			std::vector<thor_scsi::custom::aircoil_filament_t> off {{200e0, 200e0, 0e0}};
+			auto tmp = std::make_shared<nonlinearkicker_knobbed>(off);
+			this->intp = std::move(std::dynamic_pointer_cast<thor_scsi::core::Field2DInterpolationKnobbed<C>>(tmp));
+			/*
+			  std::cerr << "NonLinearKicker Type: " << std::setw(10) << name << " interpolation object " << this->intp  << std::endl;
+			  auto parent = dynamic_cast<FieldKick*>(this);
+			  std::cerr << "FieldKick:             interpolation object " << parent->getFieldInterpolator()  << std::endl;
+			*/
+		}
+
+		const char* type_name(void) const override { return "NonLinearKicker"; };
+
+		inline auto getFieldInterpolator(void) const {
+			std::stringstream strm;
+			strm << __FILE__ << ":mpole.getFieldInterpolator: this->intp " << static_cast<void *>(this->intp.get());
+			auto p = std::dynamic_pointer_cast<nonlinearkicker_knobbed>(this->intp);
+			strm << " p " << static_cast<void *>(p.get());
+			if(!p){
+				strm<<" cast failed!";
+				throw std::runtime_error(strm.str());
+			}
+			auto cp =  std::const_pointer_cast<nonlinearkicker_knobbed>(p);
+			strm << " cp " << static_cast<void *>(cp.get());
+			if(!cp){
+				strm<<" cast failed!";
+				throw std::runtime_error(strm.str());
+			}
+					    // std::cerr << strm.str() << std::endl;
+			return cp;
+		}
+
+		inline void setFieldInterpolator(std::shared_ptr<thor_scsi::custom::NonLinearKickerInterpolationKnobbed<C>> intp) {
+			auto p = std::dynamic_pointer_cast<thor_scsi::core::Field2DInterpolationKnobbed<C>>(intp);
+			if(!p){
+				throw std::runtime_error("Could not cast multipole to Field2DInterpolation");
+			}
+			this->intp = p;
+		}
+
+		//thor_scsi::core::TwoDimensionalMultipoles* intp;
+	};
+
+
+    typedef class NonLinearKickerTypeWithKnob<core::StandardDoubleType> NonLinearKickerType;
+    typedef class NonLinearKickerTypeWithKnob<core::TpsaVariantType> NonLinearKickerTypeTpsa;
+
+} // Name space
+
+#endif // _THOR_SCSI_ELEMENTS_NONLINEAR_KICKER_H_
+/*
+ * Local Variables:
+ * mode: c++
+ * c-file-style: "python"
+ * End:
+ */

--- a/src/thor_scsi/custom/nonlinear_kicker_interpolation.cc
+++ b/src/thor_scsi/custom/nonlinear_kicker_interpolation.cc
@@ -24,12 +24,12 @@ const std::vector<tsu::aircoil_filament_t> tsu::construct_aircoil_filaments(
 
 
 template<class C>
-void tsu::NonlinearKickerKnobbed<C>::show(std::ostream& strm, int level) const
+void tsu::NonLinearKickerInterpolationKnobbed<C>::show(std::ostream& strm, int level) const
 {
-    strm << "NonlinearKickerKnobbed({ ";
+    strm << "NonLinearKickerInterpolationKnobbed({ ";
     tsu::AirCoilMagneticFieldKnobbed<C>::show(strm, level);
     strm << "})";
 }
 
-template void tsu::NonlinearKickerKnobbed<tsc::StandardDoubleType>::show(std::ostream& strm, int level) const;
-template void tsu::NonlinearKickerKnobbed<tsc::TpsaVariantType>::show(std::ostream& strm, int level) const;
+template void tsu::NonLinearKickerInterpolationKnobbed<tsc::StandardDoubleType>::show(std::ostream& strm, int level) const;
+template void tsu::NonLinearKickerInterpolationKnobbed<tsc::TpsaVariantType>::show(std::ostream& strm, int level) const;

--- a/src/thor_scsi/custom/nonlinear_kicker_interpolation.h
+++ b/src/thor_scsi/custom/nonlinear_kicker_interpolation.h
@@ -15,17 +15,20 @@ namespace thor_scsi::custom {
     const std::vector<aircoil_filament_t> construct_aircoil_filaments(const std::vector<aircoil_filament_t>& filaments_one_quater);
 
     template<class C>
-    class NonlinearKickerKnobbed: public AirCoilMagneticFieldKnobbed<C>  {
+    class NonLinearKickerInterpolationKnobbed: public AirCoilMagneticFieldKnobbed<C>  {
 
     public:
-	NonlinearKickerKnobbed(const std::vector<aircoil_filament_t>& filaments_one_quater)
+	NonLinearKickerInterpolationKnobbed(const std::vector<aircoil_filament_t> filaments_one_quater)
 	    : AirCoilMagneticFieldKnobbed<C>(construct_aircoil_filaments(filaments_one_quater))
 	    {}
 
+	inline void setFilaments(const std::vector<aircoil_filament_t> filaments_one_quater) {
+        this->setFilaments(construct_aircoil_filaments(filaments_one_quater));
+    }
 	void show(std::ostream&, int level) const override;
     };
 
-    typedef  NonlinearKickerKnobbed<thor_scsi::core::StandardDoubleType> NonlinearKicker;
+    typedef  NonLinearKickerInterpolationKnobbed<thor_scsi::core::StandardDoubleType> NonLinearKickerInterpolation;
 } //namespace thor_scsi::custom
 
 #endif /* _THOR_SCSI_CUSTOM_NONLINEAR_KICKER_INTERPOLATION_H_ */

--- a/src/thor_scsi/custom/test_nonlinear_kicker.cc
+++ b/src/thor_scsi/custom/test_nonlinear_kicker.cc
@@ -1,0 +1,183 @@
+#define BOOST_TEST_MODULE nonlinear_kicker
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include <thor_scsi/custom/nonlinear_kicker.h>
+#include <iostream>
+
+namespace tsc = thor_scsi::core;
+namespace tsu = thor_scsi::custom;
+
+static void check_identity_mat(const arma::mat& mat){
+    arma::mat Id(mat.n_rows, mat.n_cols, arma::fill::eye);
+    arma::mat diff = mat - Id;
+    arma::mat chk = arma::sum(arma::sum(arma::abs(diff), 1), 1);
+    double val = chk(0, 0);
+    BOOST_CHECK_SMALL(val, 1e-12);
+}
+
+static void check_vec_zero(const std::vector<double>& vec)
+{
+    for(const auto& e: vec){
+        BOOST_CHECK_SMALL(e, 1e-12);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test10_nlk_zero_pos)
+{
+	Config C;
+	C.set<std::string>("name", "test");
+	C.set<double>("Method", 4.0);
+	C.set<double>("N", 1);
+	C.set<double>("L", 0e0);
+
+	tsc::ConfigType  calc_config;
+	tsu::NonLinearKickerType nlk(C);
+
+	BOOST_CHECK_EQUAL(nlk.isThick(), false);
+	BOOST_CHECK_SMALL(nlk.getLength(), 1e-12);
+	BOOST_CHECK_SMALL(nlk.getFieldInterpolator()->getScale(), 1e-12);
+
+	auto desc = std::make_shared<gtpsa::desc>(6, 2);
+	gtpsa::ss_vect<gtpsa::tpsa> v1 (desc,1);
+    v1.set_identity();
+	nlk.propagate(calc_config, v1);
+
+    check_identity_mat( v1.jacobian());
+    check_vec_zero(v1.cst());
+
+}
+
+
+BOOST_AUTO_TEST_CASE(test20_nlk_kicker)
+{
+    Config C;
+    C.set<std::string>("name", "test");
+    C.set<double>("Method", 4.0);
+    C.set<double>("N", 1);
+    C.set<double>("L", 0e0);
+
+    // Non linear kicker ... a bit easier to trace
+    const double current = 2e2;
+    const double wire_pos = 20e-3;
+    tsu::aircoil_filament_t wire = {wire_pos, wire_pos,   current};
+    std::vector<tsu::aircoil_filament_t> currents {wire};
+
+    tsc::ConfigType  calc_config;
+    tsu::NonLinearKickerType nlk(C);
+
+    auto intp = std::make_shared<tsu::NonLinearKickerInterpolation>(currents);
+    nlk.setFieldInterpolator(intp);
+
+    BOOST_CHECK_EQUAL(nlk.isThick(), false);
+    BOOST_CHECK_SMALL(nlk.getLength(), 1e-12);
+
+    auto desc = std::make_shared<gtpsa::desc>(6, 2);
+    gtpsa::ss_vect<gtpsa::tpsa> v1 (desc,1);
+    v1.set_identity();
+    intp->setScale(0e0);
+    BOOST_CHECK_SMALL(intp->getScale(), 1e-12);
+
+    // check if off at center
+    nlk.propagate(calc_config, v1);
+    std::cout << "nlk off at center " <<v1 << std::endl;
+    check_vec_zero(v1.cst());
+    check_identity_mat(v1.jacobian());
+
+    // check if on at center
+    v1.set_identity();
+    nlk.propagate(calc_config, v1);
+    intp->setScale(1e0);
+    BOOST_CHECK_CLOSE(intp->getScale(), 1e0, 1e-12);
+    std::cout << "nlk on: but center "<< v1 << std::endl;
+
+    check_vec_zero(v1.cst());
+    check_identity_mat(v1.jacobian());
+
+    // check if on at center
+    v1.set_identity();
+    v1[0].set(0e0, wire_pos);
+    BOOST_CHECK_CLOSE(v1.cst()[0], wire_pos, 1e-12);
+    nlk.propagate(calc_config, v1);
+    intp->setScale(1e0);
+    BOOST_CHECK_CLOSE(intp->getScale(), 1e0, 1e-12);
+    std::cout << "nlk on: but at wire pos "<< v1 << std::endl;
+
+    std::vector<double> vec = v1.cst();
+    BOOST_CHECK_CLOSE(vec[0], wire_pos, 1e-12);
+
+    // 4 wires, wires in corner of square
+    // as it is position in x, only the wires of quadrant 2 and 3 contribute
+    // 4 and 1 cancel each other
+    const double px = vec[1];
+    const double wp2 = wire_pos/2, r2 = wp2*wp2 + 4 * wire_pos*wire_pos;
+    const double root = (1/wp2 * 16e0/100e0);
+    const double expected_px     = -1e-7 * current / 2e0 /  root;
+    const double expected_dx_dy  = -1e-7 * current / 2e0 / (root*root)  * 2 * wire_pos;
+    BOOST_CHECK_CLOSE(px, expected_px, 1e-12);
+
+    vec[0] = 0e0;
+    vec[1] = 0e0;
+    check_vec_zero(vec);
+    arma::mat jac = v1.jacobian();
+
+#warning "Missing check for derivatives"
+    //BOOST_CHECK_CLOSE(jac(1, 0), expected_dx_dy, 1e-12);
+    //BOOST_CHECK_CLOSE(jac(3, 2), expected_dx_dy, 1e-12);
+
+    jac(1, 0) = 0e0;
+    jac(3, 2) = 0e0;
+
+    check_identity_mat(jac);
+
+}
+
+
+BOOST_AUTO_TEST_CASE(test30_nlk_bessyii_kicker)
+{
+	Config C;
+	C.set<std::string>("name", "test");
+	C.set<double>("Method", 4.0);
+	C.set<double>("N", 1);
+	C.set<double>("L", 0e0);
+
+	// BESSY II non linear kicker
+	const double s = 14e-2, scale = 1 - s, current = 700, m_cur = current * s, cur = current * scale * scale;
+    const double wire_pos = 8e-3;
+	tsu::aircoil_filament_t outer  = {17e-3 * scale, 15e-3 * scale,   cur};
+	tsu::aircoil_filament_t inner  = { wire_pos * scale,  7e-3 * scale,   cur};
+	tsu::aircoil_filament_t mirror = { wire_pos * scale,  5e-3 * scale, m_cur};
+	std::vector<tsu::aircoil_filament_t> currents {inner, outer, mirror};
+
+	tsc::ConfigType  calc_config;
+	tsu::NonLinearKickerType nlk(C);
+
+	auto intp = std::make_shared<tsu::NonLinearKickerInterpolation>(currents);
+	nlk.setFieldInterpolator(intp);
+
+	BOOST_CHECK_EQUAL(nlk.isThick(), false);
+	BOOST_CHECK_SMALL(nlk.getLength(), 1e-12);
+
+	auto desc = std::make_shared<gtpsa::desc>(6, 2);
+	gtpsa::ss_vect<gtpsa::tpsa> v1 (desc,1);
+	v1.set_identity();
+	intp->setScale(0e0);
+	BOOST_CHECK_SMALL(intp->getScale(), 1e-12);
+	nlk.propagate(calc_config, v1);
+	std::cout << "nlk off at center" <<v1 << std::endl;
+
+    v1.set_identity();
+    nlk.propagate(calc_config, v1);
+    intp->setScale(1e0);
+    BOOST_CHECK_CLOSE(intp->getScale(), 1e0, 1e-12);
+    std::cout << "nlk on: but center "<< v1 << std::endl;
+
+    v1.set_identity();
+    v1[0].set(0e0, wire_pos);
+    nlk.propagate(calc_config, v1);
+    intp->setScale(1e0);
+    BOOST_CHECK_CLOSE(intp->getScale(), 1e0, 1e-12);
+    std::cout << "nlk on: but at wire pos "<< v1 << std::endl;
+
+
+
+}

--- a/src/thor_scsi/custom/test_nonlinear_kicker_interpolation.cc
+++ b/src/thor_scsi/custom/test_nonlinear_kicker_interpolation.cc
@@ -3,6 +3,8 @@
 #include <boost/test/unit_test.hpp>
 
 #include <thor_scsi/custom/nonlinear_kicker_interpolation.h>
+#include <iostream>
+
 
 namespace tsc = thor_scsi::core;
 namespace tsu = thor_scsi::custom;

--- a/src/thor_scsi/custom/test_nonlinear_kicker_interpolation.cc
+++ b/src/thor_scsi/custom/test_nonlinear_kicker_interpolation.cc
@@ -12,17 +12,120 @@ BOOST_AUTO_TEST_CASE(test10_nlk_zero_pos)
 
     // BESSY II non linear kicker
     const double s = 14e-2, scale = 1 - s, current = 700, m_cur = current * s, cur = current * scale * scale;
-
+    const double wire_pos = 8e-3;
     tsu::aircoil_filament_t outer  = {17e-3 * scale, 15e-3 * scale,   cur};
-    tsu::aircoil_filament_t inner  = { 8e-3 * scale,  7e-3 * scale,   cur};
-    tsu::aircoil_filament_t mirror = { 8e-3 * scale,  5e-3 * scale, m_cur};
-    tsu:: NonlinearKicker nlk({inner, outer, mirror});
+    tsu::aircoil_filament_t inner  = { wire_pos * scale,  7e-3 * scale,   cur};
+    tsu::aircoil_filament_t mirror = { wire_pos * scale,  5e-3 * scale, m_cur};
+    tsu:: NonLinearKickerInterpolation nlk({inner, outer, mirror});
 
-    const double x = 0e0, y = 0e0;
-    double Bx=1e200, By=1e200;
-    nlk.field(x, y, &Bx, &By);
+    // check that no field returned at scale of 0
+    BOOST_CHECK_SMALL(nlk.getScale(), 0e0);
+    {
+        const double x = 0e0, y = 0e0;
+        double Bx=1e200, By=1e200;
+        nlk.field(x, y, &Bx, &By);
 
-    BOOST_CHECK_SMALL(Bx, 1e-12);
-    BOOST_CHECK_SMALL(By, 1e-12);
+        BOOST_CHECK_SMALL(Bx, 1e-12);
+        BOOST_CHECK_SMALL(By, 1e-12);
+    }
+
+    // check that no field returned at scale of 0 if right below the "wire"
+    {
+        const double x = 8e-3, y = 0e0;
+        double Bx=1e200, By=1e200;
+
+        nlk.field(x, y, &Bx, &By);
+
+        BOOST_CHECK_SMALL(Bx, 1e-12);
+        BOOST_CHECK_SMALL(By, 1e-12);
+    }
+
+    // check that field returned at scale of 1 if right below the "wire"
+    const double ref_field_y = 0.0232;
+    nlk.setScale(1e0);
+    {
+        const double x = wire_pos, y = 0e0;
+        double Bx=1e200, By=1e200;
+
+        nlk.field(x, y, &Bx, &By);
+
+        BOOST_CHECK_SMALL(Bx,              1e-12);
+        BOOST_CHECK_CLOSE(By, ref_field_y, 0.1);
+    }
+
+
+    auto desc = std::make_shared<gtpsa::desc>(6,2);
+    {
+        gtpsa::tpsa x(desc, 1), y(desc, 1), Bx(desc, 1), By(desc, 1);
+        x.setVariable(0e0, 0 + 1);
+        y.setVariable(0e0, 2 + 1);
+
+        // zero for zero field at zero position if scale at zero
+        nlk.setScale(0e0);
+
+        nlk.field(x, y, &Bx, &By);
+
+
+        BOOST_CHECK_SMALL(Bx.cst(), 1e-12);
+        BOOST_CHECK_SMALL(By.cst(), 1e-12);
+
+        // zero for zero field at zero position if scale at one
+        nlk.setScale(1e0);
+
+        nlk.field(x, y, &Bx, &By);
+
+        BOOST_CHECK_SMALL(Bx.cst(), 1e-12);
+        BOOST_CHECK_SMALL(By.cst(), 1e-12);
+
+        // check if scaling works for full field and for the tpsa series
+        double scale = 1.0;
+        nlk.setScale(scale);
+        x.set(0e0, wire_pos);
+        BOOST_CHECK_CLOSE(x.cst(), wire_pos, 1e-12);
+
+        nlk.field(x, y, &Bx, &By);
+
+        std::cout << "scale " << scale
+                  << "\nx\n" << x
+                  << "y\n" << y
+                  << "Bx\n" << Bx
+                  << "By\n" << By
+                  << std::endl;
+
+        BOOST_CHECK_SMALL(Bx.cst(), 1e-12);
+        BOOST_CHECK_CLOSE(By.cst(), ref_field_y * scale, 0.1);
+
+        // does it work at 10 % of  the field
+        scale = 0.1;
+        nlk.setScale(scale);
+
+        nlk.field(x, y, &Bx, &By);
+        std::cout << "scale " << scale
+                  << "\nx\n" << x
+                  << "y\n" << y
+                  << "Bx\n" << Bx
+                  << "By\n" << By
+                  << std::endl;
+
+        BOOST_CHECK_SMALL(Bx.cst(), 1e-12);
+        BOOST_CHECK_CLOSE(By.cst(), ref_field_y * scale, 0.1);
+
+        // does it work at 0 the field
+        scale = 0e0;
+        nlk.setScale(scale);
+
+        nlk.field(x, y, &Bx, &By);
+        std::cout << "scale " << scale
+                  << "\nx\n" << x
+                  << "y\n" << y
+                  << "Bx\n" << Bx
+                  << "By\n" << By
+                  << std::endl;
+
+        BOOST_CHECK_SMALL(Bx.cst(), 1e-12);
+        BOOST_CHECK_CLOSE(By.cst(), ref_field_y * scale, 0.1);
+
+    }
+
 
 }

--- a/src/thor_scsi/elements/field_kick.cc
+++ b/src/thor_scsi/elements/field_kick.cc
@@ -451,7 +451,7 @@ thinKickAndRadiate(const thor_scsi::core::ConfigType &conf,
 	// const auto x = ps[x_];
 	// const auto y = ps[y_];
         const gtpsa::ss_vect<T> ps0 = ps.clone();
-	T BxoBrho(ps[0]), ByoBrho(ps[0]);
+	T BxoBrho = gtpsa::same_as_instance(ps[0]), ByoBrho = gtpsa::same_as_instance(ps[2]);
 
 	//intp.field(ps[x_], ps[y_], &BxoBrho, &ByoBrho);
 	/*
@@ -459,7 +459,6 @@ thinKickAndRadiate(const thor_scsi::core::ConfigType &conf,
 		throw std::logic_error("Interpolation object not set!");
 	}
 	*/
-
 	// THOR_SCSI_LOG(DEBUG) << "\n  thinKickAndRadiate ->: ps = " << ps << "\n";
 
 	intp.field(ps[x_], ps[y_], &BxoBrho, &ByoBrho);

--- a/src/thor_scsi/std_machine/accelerator.cc
+++ b/src/thor_scsi/std_machine/accelerator.cc
@@ -40,7 +40,7 @@ ts::AcceleratorKnobbable<C>::AcceleratorKnobbable(const Config & conf, bool mark
 
 template<class C>
 ts::AcceleratorKnobbable<C>::AcceleratorKnobbable
-(const std::vector<std::shared_ptr<thor_scsi::core::ElemTypeKnobbed>>& elements, bool marker_at_start)
+(const std::vector<std::shared_ptr<thor_scsi::core::ElemTypeKnobbed>> elements, bool marker_at_start)
     :tsc::Machine(vec_elem_type_to_cell_void(elements))
 {
     if(marker_at_start){
@@ -50,7 +50,7 @@ ts::AcceleratorKnobbable<C>::AcceleratorKnobbable
 
 template<class C>
 ts::AcceleratorKnobbable<C>::AcceleratorKnobbable
-(std::vector<std::shared_ptr<thor_scsi::core::CellVoid>>& elements, bool marker_at_start)
+(std::vector<std::shared_ptr<thor_scsi::core::CellVoid>> elements, bool marker_at_start)
     : tsc::Machine(elements)
 {
     if(marker_at_start){
@@ -214,13 +214,13 @@ propagate(thor_scsi::core::ConfigType& conf, ss_vect_tpsa &ps, size_t start,
 template ts::AcceleratorKnobbable<tsc::StandardDoubleType>::AcceleratorKnobbable(const Config &conf, bool add_marker_at_start);
 template ts::AcceleratorKnobbable<tsc::TpsaVariantType>::AcceleratorKnobbable(const Config &conf, bool add_marker_at_start);
 template ts::AcceleratorKnobbable<tsc::StandardDoubleType>::
-AcceleratorKnobbable(std::vector<std::shared_ptr<thor_scsi::core::CellVoid>>& elements, bool add_marker_at_start);
+AcceleratorKnobbable(std::vector<std::shared_ptr<thor_scsi::core::CellVoid>> elements, bool add_marker_at_start);
 template ts::AcceleratorKnobbable<tsc::TpsaVariantType>::
-AcceleratorKnobbable(std::vector<std::shared_ptr<thor_scsi::core::CellVoid>>& elements, bool add_marker_at_start);
+AcceleratorKnobbable(std::vector<std::shared_ptr<thor_scsi::core::CellVoid>> elements, bool add_marker_at_start);
 template ts::AcceleratorKnobbable<tsc::StandardDoubleType>::
-AcceleratorKnobbable(const std::vector<std::shared_ptr<thor_scsi::core::ElemTypeKnobbed>>& elements, bool add_marker_at_start);
+AcceleratorKnobbable(const std::vector<std::shared_ptr<thor_scsi::core::ElemTypeKnobbed>> elements, bool add_marker_at_start);
 template ts::AcceleratorKnobbable<tsc::TpsaVariantType>::
-AcceleratorKnobbable(const std::vector<std::shared_ptr<thor_scsi::core::ElemTypeKnobbed>>& elements, bool add_marker_at_start);
+AcceleratorKnobbable(const std::vector<std::shared_ptr<thor_scsi::core::ElemTypeKnobbed>> elements, bool add_marker_at_start);
 template void ts::AcceleratorKnobbable<tsc::TpsaVariantType>::addMarkerAtStart(void);
 template void ts::AcceleratorKnobbable<tsc::StandardDoubleType>::addMarkerAtStart(void);
 

--- a/src/thor_scsi/std_machine/accelerator.h
+++ b/src/thor_scsi/std_machine/accelerator.h
@@ -50,10 +50,10 @@ namespace thor_scsi {
 		 */
 		/*
 		*/
-		AcceleratorKnobbable(std::vector<std::shared_ptr<thor_scsi::core::CellVoid>>& elements,
+		AcceleratorKnobbable(std::vector<std::shared_ptr<thor_scsi::core::CellVoid>> elements,
 				     bool add_marker_at_start=false);
 
-		AcceleratorKnobbable(const std::vector<std::shared_ptr<thor_scsi::core::ElemTypeKnobbed>>& elements,
+		AcceleratorKnobbable(const std::vector<std::shared_ptr<thor_scsi::core::ElemTypeKnobbed>> elements,
 				     bool add_marker_at_start=false);
 		/** @brief pass the given state through the machine
 		 *

--- a/src/thor_scsi/std_machine/std_machine.cc
+++ b/src/thor_scsi/std_machine/std_machine.cc
@@ -8,10 +8,12 @@
 #include <thor_scsi/elements/cavity.h>
 #include <thor_scsi/elements/bending.h>
 #include <thor_scsi/elements/corrector.h>
+#include <thor_scsi/custom/nonlinear_kicker.h>
 
 namespace ts = thor_scsi;
 namespace tsc = thor_scsi::core;
 namespace tse = thor_scsi::elements;
+namespace tsu = thor_scsi::custom;
 
 int
 ts::register_elements(void)
@@ -26,6 +28,7 @@ ts::register_elements(void)
 	tsc::Machine::registerElement<tse::HorizontalSteererType>("HorizontalSteerer");
 	tsc::Machine::registerElement<tse::VerticalSteererType>("VerticalSteerer");
 	tsc::Machine::registerElement<tse::BendingType>("Bending");
+	tsc::Machine::registerElement<tsu::NonLinearKickerType>("NonLinearKicker");
 
 	// tsc::Machine::registerElement<tse::MpoleType>("mpole");
 	return 1;


### PR DESCRIPTION

Fixed field calulation:
	start from new element: tpsa reset would need to handled
        carefully

Non linear kicker interpolation renamed to include interpolation in the name

Added non linear kicker element: cpp implementation
Added test for this element

Testing non linear kicker interpolation that "previous field information
is removed"

python: added nonlinear kicker element and interpolation
        filaments exported as dedicated type

python examples: updated to new nlk interface

Memory leak test slipped in:  accelerator init with vector instead with reference

